### PR TITLE
feat: Webpacker/Sprockets support + pagination & form fixes

### DIFF
--- a/app/controllers/prompt_tracker/ab_tests_controller.rb
+++ b/app/controllers/prompt_tracker/ab_tests_controller.rb
@@ -28,7 +28,7 @@ module PromptTracker
       end
 
       # Pagination
-      @ab_tests = @ab_tests.page(params[:page]).per(20)
+      @ab_tests = pt_paginate(@ab_tests, per_page: 20)
 
       # Get prompts for filter dropdown
       @prompts = Agent.order(:name)

--- a/app/controllers/prompt_tracker/application_controller.rb
+++ b/app/controllers/prompt_tracker/application_controller.rb
@@ -7,6 +7,14 @@ module PromptTracker
     helper DatasetsHelper
     helper TestsHelper
 
+    private
+
+    # Paginate a scope using Kaminari, bypassing will_paginate conflicts.
+    # Use this instead of .page(params[:page]).per(N) in all controllers.
+    def pt_paginate(scope, per_page: 25)
+      scope.model.pt_paginate(scope, page: params[:page], per_page: per_page)
+    end
+
     # Override default_url_options to support multi-tenant mounting.
     # When the engine is mounted under a scoped route like /orgs/:org_slug/app,
     # the url_options_provider configuration allows the host app to provide

--- a/app/controllers/prompt_tracker/deployed_agents_controller.rb
+++ b/app/controllers/prompt_tracker/deployed_agents_controller.rb
@@ -8,10 +8,10 @@ module PromptTracker
     # GET /agents
     # Dashboard showing all deployed agents
     def index
-      @agents = DeployedAgent.includes(:agent_version)
-                             .order(created_at: :desc)
-                             .page(params[:page])
-                             .per(20)
+      @agents = pt_paginate(
+        DeployedAgent.includes(:agent_version).order(created_at: :desc),
+        per_page: 20
+      )
 
       # Apply filters
       @agents = @agents.where(status: params[:status]) if params[:status].present?

--- a/app/controllers/prompt_tracker/deployed_agents_controller.rb
+++ b/app/controllers/prompt_tracker/deployed_agents_controller.rb
@@ -8,13 +8,12 @@ module PromptTracker
     # GET /agents
     # Dashboard showing all deployed agents
     def index
-      @agents = pt_paginate(
-        DeployedAgent.includes(:agent_version).order(created_at: :desc),
-        per_page: 20
-      )
+      @agents = DeployedAgent.includes(:agent_version).order(created_at: :desc)
 
       # Apply filters
       @agents = @agents.where(status: params[:status]) if params[:status].present?
+
+      @agents = pt_paginate(@agents, per_page: 20)
 
       # Statistics
       @total_agents = DeployedAgent.count

--- a/app/controllers/prompt_tracker/environment_variables_controller.rb
+++ b/app/controllers/prompt_tracker/environment_variables_controller.rb
@@ -13,7 +13,7 @@ module PromptTracker
         @environment_variables = @environment_variables.search(params[:q])
       end
 
-      @environment_variables = @environment_variables.page(params[:page]).per(20)
+      @environment_variables = pt_paginate(@environment_variables, per_page: 20)
     end
 
     # GET /environment_variables/:id

--- a/app/controllers/prompt_tracker/evaluations_controller.rb
+++ b/app/controllers/prompt_tracker/evaluations_controller.rb
@@ -47,7 +47,7 @@ module PromptTracker
       end
 
       # Pagination
-      @evaluations = @evaluations.page(params[:page]).per(20)
+      @evaluations = pt_paginate(@evaluations, per_page: 20)
 
       # Get filter options
       @evaluator_types = Evaluation.distinct.pluck(:evaluator_type).compact.sort

--- a/app/controllers/prompt_tracker/functions_controller.rb
+++ b/app/controllers/prompt_tracker/functions_controller.rb
@@ -44,7 +44,7 @@ module PromptTracker
       end
 
       # Pagination
-      @functions = @functions.page(params[:page]).per(20)
+      @functions = pt_paginate(@functions, per_page: 20)
 
       # Get filter options
       @categories = FunctionDefinition.distinct.pluck(:category).compact.sort
@@ -55,10 +55,7 @@ module PromptTracker
     # GET /functions/:id
     # Show function details with execution history
     def show
-      @executions = @function.function_executions
-                             .order(executed_at: :desc)
-                             .page(params[:page])
-                             .per(20)
+      @executions = pt_paginate(@function.function_executions.order(executed_at: :desc), per_page: 20)
 
       # Calculate stats from actual executions (not cached counter)
       all_executions = @function.function_executions

--- a/app/controllers/prompt_tracker/monitoring/agent_versions_controller.rb
+++ b/app/controllers/prompt_tracker/monitoring/agent_versions_controller.rb
@@ -31,7 +31,7 @@ module PromptTracker
         end
 
         # Pagination
-        @tracked_calls = @tracked_calls.page(params[:page]).per(20)
+        @tracked_calls = pt_paginate(@tracked_calls, per_page: 20)
 
         # Statistics
         all_calls = LlmResponse.tracked_calls.where(agent_version_id: @version.id)

--- a/app/controllers/prompt_tracker/monitoring/evaluations_controller.rb
+++ b/app/controllers/prompt_tracker/monitoring/evaluations_controller.rb
@@ -59,7 +59,7 @@ module PromptTracker
         end
 
         # Pagination
-        @evaluations = @evaluations.page(params[:page]).per(50)
+        @evaluations = pt_paginate(@evaluations, per_page: 50)
 
         # Get filter options
         @prompts = Agent.active.order(:name)

--- a/app/controllers/prompt_tracker/monitoring/llm_responses_controller.rb
+++ b/app/controllers/prompt_tracker/monitoring/llm_responses_controller.rb
@@ -69,7 +69,7 @@ module PromptTracker
         end
 
         # Pagination
-        @responses = @responses.page(params[:page]).per(50)
+        @responses = pt_paginate(@responses, per_page: 50)
 
         # Get filter options
         @prompts = Agent.active.order(:name)

--- a/app/controllers/prompt_tracker/task_runs_controller.rb
+++ b/app/controllers/prompt_tracker/task_runs_controller.rb
@@ -8,14 +8,13 @@ module PromptTracker
 
     # GET /agents/:slug/runs
     def index
-      @task_runs = pt_paginate(
-        @agent.task_runs.includes(:llm_responses, :function_executions).order(created_at: :desc),
-        per_page: 20
-      )
+      @task_runs = @agent.task_runs.includes(:llm_responses, :function_executions).order(created_at: :desc)
 
       # Apply filters
       @task_runs = @task_runs.where(status: params[:status]) if params[:status].present?
       @task_runs = @task_runs.where(trigger_type: params[:trigger_type]) if params[:trigger_type].present?
+
+      @task_runs = pt_paginate(@task_runs, per_page: 20)
 
       # Statistics
       @total_runs = @agent.task_runs.count

--- a/app/controllers/prompt_tracker/task_runs_controller.rb
+++ b/app/controllers/prompt_tracker/task_runs_controller.rb
@@ -8,11 +8,10 @@ module PromptTracker
 
     # GET /agents/:slug/runs
     def index
-      @task_runs = @agent.task_runs
-                         .includes(:llm_responses, :function_executions)
-                         .order(created_at: :desc)
-                         .page(params[:page])
-                         .per(20)
+      @task_runs = pt_paginate(
+        @agent.task_runs.includes(:llm_responses, :function_executions).order(created_at: :desc),
+        per_page: 20
+      )
 
       # Apply filters
       @task_runs = @task_runs.where(status: params[:status]) if params[:status].present?

--- a/app/controllers/prompt_tracker/testing/agents_controller.rb
+++ b/app/controllers/prompt_tracker/testing/agents_controller.rb
@@ -38,7 +38,7 @@ module PromptTracker
       end
 
       # Pagination
-      @agents = @agents.page(params[:page]).per(20)
+      @agents = pt_paginate(@agents, per_page: 20)
 
       # Get all categories and tags for filters
       @categories = Agent.distinct.pluck(:category).compact.sort

--- a/app/controllers/prompt_tracker/testing/agents_controller.rb
+++ b/app/controllers/prompt_tracker/testing/agents_controller.rb
@@ -39,6 +39,7 @@ module PromptTracker
 
       # Pagination
       @agents = pt_paginate(@agents, per_page: 20)
+      @prompts = @agents # View uses @prompts (legacy naming)
 
       # Get all categories and tags for filters
       @categories = Agent.distinct.pluck(:category).compact.sort
@@ -49,6 +50,7 @@ module PromptTracker
     # Show agent details with all versions
     def show
       @agent = Agent.includes(agent_versions: [ :llm_responses, :evaluator_configs ]).find(params[:id])
+      @prompt = @agent # View uses @prompt (legacy naming)
       @versions = @agent.agent_versions.order(version_number: :desc)
       @active_version = @agent.active_version
       @latest_version = @agent.latest_version

--- a/app/controllers/prompt_tracker/testing/datasets_controller.rb
+++ b/app/controllers/prompt_tracker/testing/datasets_controller.rb
@@ -10,6 +10,21 @@ module PromptTracker
     # This controller inherits all CRUD logic from DatasetsControllerBase.
     #
     class DatasetsController < DatasetsControllerBase
+      # Flat route - no testable context needed
+      skip_before_action :set_testable, only: :row_count
+      skip_before_action :set_dataset, only: :row_count
+
+      # GET /testing/datasets/:id/row_count
+      # Returns JSON with the row count for a dataset (used by run_test_modal JS)
+      def row_count
+        dataset = Dataset.find_by(id: params[:id])
+        if dataset
+          render json: { count: dataset.dataset_rows.count }
+        else
+          render json: { count: 0 }, status: :not_found
+        end
+      end
+
       private
 
       # Set the testable (AgentVersion) and related instance variables

--- a/app/controllers/prompt_tracker/testing/datasets_controller_base.rb
+++ b/app/controllers/prompt_tracker/testing/datasets_controller_base.rb
@@ -46,7 +46,7 @@ module PromptTracker
 
       # GET /datasets/:id
       def show
-        @rows = @dataset.dataset_rows.recent.page(params[:page]).per(50)
+        @rows = pt_paginate(@dataset.dataset_rows.recent, per_page: 50)
       end
 
       # GET /datasets/:id/edit

--- a/app/controllers/prompt_tracker/testing/test_runs_controller.rb
+++ b/app/controllers/prompt_tracker/testing/test_runs_controller.rb
@@ -8,10 +8,10 @@ module PromptTracker
 
       # GET /testing/runs
       def index
-        @test_runs = TestRun.includes(:test)
-                            .order(created_at: :desc)
-                            .page(params[:page])
-                            .per(50)
+        @test_runs = pt_paginate(
+          TestRun.includes(:test).order(created_at: :desc),
+          per_page: 50
+        )
 
         # Filter by status if provided
         if params[:status].present?

--- a/app/helpers/prompt_tracker/application_helper.rb
+++ b/app/helpers/prompt_tracker/application_helper.rb
@@ -8,6 +8,45 @@ module PromptTracker
     include EvaluatorConfigsHelper
     include UrlHelper
     include TestsHelper
+
+    # Generate a native browser importmap + module script tag for PromptTracker JS.
+    # Works without importmap-rails gem. Maps external libraries to CDN/Sprockets URLs
+    # and all engine JS files to their Sprockets asset paths.
+    def prompt_tracker_importmap_tags
+      engine_root = PromptTracker::Engine.root
+
+      # Collect all JS files from the engine
+      js_files = Dir.glob(engine_root.join("app/javascript/prompt_tracker/**/*.js")).sort
+      pins = {}
+      js_files.each do |path|
+        # Convert file path to module specifier: "prompt_tracker/controllers/tooltip_controller"
+        relative = path.sub("#{engine_root}/app/javascript/", "").sub(/\.js$/, "")
+        pins[relative] = asset_path("#{relative}.js")
+      end
+
+      # External library mappings
+      external = {
+        "@hotwired/turbo-rails" => (asset_path("turbo.min.js") rescue "https://cdn.jsdelivr.net/npm/@hotwired/turbo-rails@8.0.12/+esm"),
+        "@hotwired/stimulus" => (asset_path("stimulus.min.js") rescue "https://cdn.jsdelivr.net/npm/@hotwired/stimulus@3.2.2/+esm"),
+        "chart.js" => "https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js",
+        "bootstrap" => "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.esm.min.js",
+        "@popperjs/core" => "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/esm/index.js"
+      }
+
+      # Add alias for directory-style imports (e.g. "prompt_tracker/controllers" → index.js)
+      if pins.key?("prompt_tracker/controllers/index")
+        pins["prompt_tracker/controllers"] = pins["prompt_tracker/controllers/index"]
+      end
+
+      imports = external.merge(pins)
+      importmap_json = { imports: imports }.to_json
+
+      safe_join([
+        tag.script(importmap_json.html_safe, type: "importmap"),
+        "\n  ".html_safe,
+        tag.script("import 'prompt_tracker/application'".html_safe, type: "module")
+      ])
+    end
     # Format USD amount with dollar sign
     #
     # @param amount [Float, nil] the amount in USD

--- a/app/javascript/prompt_tracker/application.js
+++ b/app/javascript/prompt_tracker/application.js
@@ -1,7 +1,10 @@
+// PromptTracker main JavaScript entry point
+// Uses bare specifiers (e.g. "prompt_tracker/controllers") resolved by importmap
+// Works with both importmap-rails gem AND native browser importmaps
 
-// If the engine UI uses Bootstrap:
 import "@hotwired/turbo-rails"
-// Import Stimulus controllers
+
+// Import and register all Stimulus controllers
 import "prompt_tracker/controllers"
 
 // Import Chart.js UMD bundle (automatically assigns to window.Chart)

--- a/app/javascript/prompt_tracker/controllers/index.js
+++ b/app/javascript/prompt_tracker/controllers/index.js
@@ -1,6 +1,97 @@
-// Import and register all your controllers from the importmap via controllers/**/*_controller
+// Manual controller registration - works with any JS pipeline (importmap, Webpacker, Sprockets)
+// Uses bare specifiers resolved by importmap (either importmap-rails gem or native browser importmap)
 import { application } from "prompt_tracker/controllers/application"
-import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
 
-// Eager load all controllers defined in the import map under controllers/**/*_controller
-eagerLoadControllersFrom("prompt_tracker/controllers", application)
+import AgentChatController from "prompt_tracker/controllers/agent_chat_controller"
+import AgentTypeSelectorController from "prompt_tracker/controllers/agent_type_selector_controller"
+import ApiKeyController from "prompt_tracker/controllers/api_key_controller"
+import AssistantChatbotController from "prompt_tracker/controllers/assistant_chatbot_controller"
+import BatchSelectController from "prompt_tracker/controllers/batch_select_controller"
+import ColumnVisibilityController from "prompt_tracker/controllers/column_visibility_controller"
+import EvaluatorConfigFormController from "prompt_tracker/controllers/evaluator_config_form_controller"
+import EvaluatorConfigsController from "prompt_tracker/controllers/evaluator_configs_controller"
+import EvaluatorEditController from "prompt_tracker/controllers/evaluator_edit_controller"
+import EvaluatorEditFormController from "prompt_tracker/controllers/evaluator_edit_form_controller"
+import FileManagementController from "prompt_tracker/controllers/file_management_controller"
+import FunctionAiGeneratorController from "prompt_tracker/controllers/function_ai_generator_controller"
+import FunctionCodeTemplatesController from "prompt_tracker/controllers/function_code_templates_controller"
+import FunctionEditorController from "prompt_tracker/controllers/function_editor_controller"
+import FunctionLanguageSwitcherController from "prompt_tracker/controllers/function_language_switcher_controller"
+import FunctionParametersExamplesController from "prompt_tracker/controllers/function_parameters_examples_controller"
+import FunctionTestController from "prompt_tracker/controllers/function_test_controller"
+import LazyEditModalController from "prompt_tracker/controllers/lazy_edit_modal_controller"
+import LinkedFiltersController from "prompt_tracker/controllers/linked_filters_controller"
+import ModalFixController from "prompt_tracker/controllers/modal_fix_controller"
+import MonacoEditorController from "prompt_tracker/controllers/monaco_editor_controller"
+import PatternMatchFormController from "prompt_tracker/controllers/pattern_match_form_controller"
+import PatternsController from "prompt_tracker/controllers/patterns_controller"
+import PlaygroundConversationController from "prompt_tracker/controllers/playground_conversation_controller"
+import PlaygroundFileSearchController from "prompt_tracker/controllers/playground_file_search_controller"
+import PlaygroundFunctionsController from "prompt_tracker/controllers/playground_functions_controller"
+import PlaygroundGeneratePromptController from "prompt_tracker/controllers/playground_generate_prompt_controller"
+import PlaygroundModelConfigController from "prompt_tracker/controllers/playground_model_config_controller"
+import PlaygroundPreviewController from "prompt_tracker/controllers/playground_preview_controller"
+import PlaygroundPromptEditorController from "prompt_tracker/controllers/playground_prompt_editor_controller"
+import PlaygroundResponseSchemaController from "prompt_tracker/controllers/playground_response_schema_controller"
+import PlaygroundSaveController from "prompt_tracker/controllers/playground_save_controller"
+import PlaygroundSyncController from "prompt_tracker/controllers/playground_sync_controller"
+import PlaygroundSyncVisibilityController from "prompt_tracker/controllers/playground_sync_visibility_controller"
+import PlaygroundToolsController from "prompt_tracker/controllers/playground_tools_controller"
+import PlaygroundUiController from "prompt_tracker/controllers/playground_ui_controller"
+import PlaygroundVariablesController from "prompt_tracker/controllers/playground_variables_controller"
+import PromptSearchController from "prompt_tracker/controllers/prompt_search_controller"
+import ResizableColumnsController from "prompt_tracker/controllers/resizable_columns_controller"
+import RunTestModalController from "prompt_tracker/controllers/run_test_modal_controller"
+import SyntaxHighlighterController from "prompt_tracker/controllers/syntax_highlighter_controller"
+import TagsController from "prompt_tracker/controllers/tags_controller"
+import TaskTimelineController from "prompt_tracker/controllers/task_timeline_controller"
+import TemplateVariablesController from "prompt_tracker/controllers/template_variables_controller"
+import TestModeController from "prompt_tracker/controllers/test_mode_controller"
+import TooltipController from "prompt_tracker/controllers/tooltip_controller"
+
+application.register("agent-chat", AgentChatController)
+application.register("agent-type-selector", AgentTypeSelectorController)
+application.register("api-key", ApiKeyController)
+application.register("assistant-chatbot", AssistantChatbotController)
+application.register("batch-select", BatchSelectController)
+application.register("column-visibility", ColumnVisibilityController)
+application.register("evaluator-config-form", EvaluatorConfigFormController)
+application.register("evaluator-configs", EvaluatorConfigsController)
+application.register("evaluator-edit", EvaluatorEditController)
+application.register("evaluator-edit-form", EvaluatorEditFormController)
+application.register("file-management", FileManagementController)
+application.register("function-ai-generator", FunctionAiGeneratorController)
+application.register("function-code-templates", FunctionCodeTemplatesController)
+application.register("function-editor", FunctionEditorController)
+application.register("function-language-switcher", FunctionLanguageSwitcherController)
+application.register("function-parameters-examples", FunctionParametersExamplesController)
+application.register("function-test", FunctionTestController)
+application.register("lazy-edit-modal", LazyEditModalController)
+application.register("linked-filters", LinkedFiltersController)
+application.register("modal-fix", ModalFixController)
+application.register("monaco-editor", MonacoEditorController)
+application.register("pattern-match-form", PatternMatchFormController)
+application.register("patterns", PatternsController)
+application.register("playground-conversation", PlaygroundConversationController)
+application.register("playground-file-search", PlaygroundFileSearchController)
+application.register("playground-functions", PlaygroundFunctionsController)
+application.register("playground-generate-prompt", PlaygroundGeneratePromptController)
+application.register("playground-model-config", PlaygroundModelConfigController)
+application.register("playground-preview", PlaygroundPreviewController)
+application.register("playground-prompt-editor", PlaygroundPromptEditorController)
+application.register("playground-response-schema", PlaygroundResponseSchemaController)
+application.register("playground-save", PlaygroundSaveController)
+application.register("playground-sync", PlaygroundSyncController)
+application.register("playground-sync-visibility", PlaygroundSyncVisibilityController)
+application.register("playground-tools", PlaygroundToolsController)
+application.register("playground-ui", PlaygroundUiController)
+application.register("playground-variables", PlaygroundVariablesController)
+application.register("prompt-search", PromptSearchController)
+application.register("resizable-columns", ResizableColumnsController)
+application.register("run-test-modal", RunTestModalController)
+application.register("syntax-highlighter", SyntaxHighlighterController)
+application.register("tags", TagsController)
+application.register("task-timeline", TaskTimelineController)
+application.register("template-variables", TemplateVariablesController)
+application.register("test-mode", TestModeController)
+application.register("tooltip", TooltipController)

--- a/app/javascript/prompt_tracker/controllers/run_test_modal_controller.js
+++ b/app/javascript/prompt_tracker/controllers/run_test_modal_controller.js
@@ -72,9 +72,11 @@ export default class extends Controller {
     if (this.hasCustomSectionTarget) {
       this.customSectionTarget.style.display = "none"
     }
-    // Enable dataset select validation, disable custom fields validation
+    // Enable dataset select validation, disable ALL custom fields validation
     this.toggleDatasetSelectRequired(true)
     this.toggleCustomFieldsRequired(false)
+    this.toggleConversationFieldsRequired(false)
+    this.toggleSingleModeFieldsRequired(false)
   }
 
   showCustomMode() {
@@ -147,6 +149,10 @@ export default class extends Controller {
 	toggleExecutionMode() {
 		// Only relevant when custom section is present/visible
 		if (!this.hasCustomSectionTarget) return
+
+		// Skip if in dataset mode - custom fields are hidden and should not have required
+		const selectedRunMode = this.modeRadioTargets.find(radio => radio.checked)?.value
+		if (selectedRunMode === "dataset") return
 
 		const selectedExecutionMode = this.hasExecutionModeRadioTarget
 			? this.executionModeRadioTargets.find(radio => radio.checked)?.value

--- a/app/models/concerns/prompt_tracker/kaminari_pagination.rb
+++ b/app/models/concerns/prompt_tracker/kaminari_pagination.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module PromptTracker
+  # Provides Kaminari-compatible pagination that works even when the host app
+  # uses will_paginate. will_paginate overrides ActiveRecord::Relation#page,
+  # which breaks Kaminari's .page().per() chain on scoped queries and associations.
+  #
+  # Usage in controllers:
+  #   @rows = PromptTracker::DatasetRow.pt_paginate(@dataset.dataset_rows.recent, page: params[:page], per_page: 50)
+  #   # or shorter with the helper:
+  #   @rows = pt_paginate(@dataset.dataset_rows.recent, page: params[:page], per_page: 50)
+  module KaminariPagination
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Paginates any scope or association using Kaminari, bypassing will_paginate.
+      #
+      # @param scope [ActiveRecord::Relation, CollectionProxy] the scope to paginate
+      # @param page [Integer, String, nil] page number (defaults to 1)
+      # @param per_page [Integer] items per page (defaults to 25)
+      # @return [Kaminari::PaginatableArray] paginated result with total_pages, current_page, etc.
+      def pt_paginate(scope, page: nil, per_page: 25)
+        page = (page || 1).to_i
+        per_page = per_page.to_i
+        total = scope.count(:all)
+        records = scope.limit(per_page).offset((page - 1) * per_page).to_a
+
+        Kaminari.paginate_array(records, total_count: total).page(page).per(per_page)
+      end
+    end
+  end
+end

--- a/app/models/concerns/prompt_tracker/kaminari_pagination.rb
+++ b/app/models/concerns/prompt_tracker/kaminari_pagination.rb
@@ -22,7 +22,9 @@ module PromptTracker
       def pt_paginate(scope, page: nil, per_page: 25)
         page = (page || 1).to_i
         per_page = per_page.to_i
-        total = scope.count(:all)
+        # count(:all) returns a Hash when the scope has a GROUP BY clause
+        total_count = scope.count(:all)
+        total = total_count.is_a?(Hash) ? total_count.length : total_count
         records = scope.limit(per_page).offset((page - 1) * per_page).to_a
 
         Kaminari.paginate_array(records, total_count: total).page(page).per(per_page)

--- a/app/models/prompt_tracker/application_record.rb
+++ b/app/models/prompt_tracker/application_record.rb
@@ -1,5 +1,7 @@
 module PromptTracker
   class ApplicationRecord < PromptTracker.configuration.base_record_class.constantize
     self.abstract_class = true
+
+    include PromptTracker::KaminariPagination
   end
 end

--- a/app/views/layouts/prompt_tracker/application.html.erb
+++ b/app/views/layouts/prompt_tracker/application.html.erb
@@ -22,18 +22,9 @@
 
   <%= yield :head %>
 
-  <%# Load JavaScript based on available asset pipeline %>
-  <% if defined?(Importmap) %>
-    <%# Using importmap-rails %>
-    <%= javascript_importmap_tags %>
-    <%= javascript_import_module_tag "prompt_tracker/application" %>
-  <% elsif defined?(Webpacker) || defined?(Shakapacker) %>
-    <%# Using Webpacker/Shakapacker - host app should include engine assets %>
-    <%# The host app needs to add: import "prompt_tracker/application" to their pack %>
-  <% else %>
-    <%# Fallback to Sprockets %>
-    <%= javascript_include_tag "prompt_tracker/application", "data-turbo-track": "reload" %>
-  <% end %>
+  <%# Load JavaScript via native browser importmap (no importmap-rails gem needed) %>
+  <%# This maps bare specifiers like "@hotwired/stimulus" to actual URLs %>
+  <%= prompt_tracker_importmap_tags %>
 
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,9 @@ PromptTracker::Engine.routes.draw do
       end
     end
 
+    # Dataset row count (flat route for AJAX calls from run_test_modal_controller.js)
+    get "datasets/:id/row_count", to: "datasets#row_count", as: :dataset_row_count
+
     # Tests for prompt versions (not nested under prompts for simpler URLs)
     resources :agent_versions, only: [], path: "versions" do
       member do


### PR DESCRIPTION
## Summary

This PR makes PromptTracker compatible with host apps that use **Webpacker** (instead of importmap-rails), and fixes several bugs discovered during integration testing with a production Rails app (SideCare).

---

## 1. Webpacker/Sprockets support via native browser importmap

### Problem
PromptTracker requires **importmap-rails** to load its JavaScript. This breaks for host apps using **Webpacker**:
- The engine layout detects Webpacker → **loads zero JS**
- Adding `importmap-rails` to a Webpacker app creates **conflicts**
- `eagerLoadControllersFrom` from `@hotwired/stimulus-loading` is **importmap-rails specific**

### Solution
Replace the importmap-rails dependency with a **native browser importmap** (`<script type="importmap">`). No extra gem needed.

**Files changed:**
- `app/helpers/prompt_tracker/application_helper.rb` — New `prompt_tracker_importmap_tags` helper that generates a native importmap + module script tag
- `app/javascript/prompt_tracker/controllers/index.js` — Manual Stimulus controller registration (replaces `eagerLoadControllersFrom`)
- `app/javascript/prompt_tracker/application.js` — Bare specifier imports
- `app/views/layouts/prompt_tracker/application.html.erb` — Single call to helper instead of 3 conditional branches

---

## 2. Kaminari/will_paginate conflict (`undefined method 'per'`)

### Problem
When the host app uses **will_paginate**, it overrides `ActiveRecord::Relation#page`, breaking Kaminari's `.page().per()` chain on all paginated pages.

### Solution
Add `KaminariPagination` concern with `pt_paginate` helper that uses `Kaminari.paginate_array` with explicit `limit`/`offset`. Replace all `.page().per()` calls. Pagination is always applied **after** filters to avoid `where` on `PaginatableArray`.

---

## 3. Missing `row_count` route (`ActionController::RoutingError`)

### Problem
`run_test_modal_controller.js` fetches `/testing/datasets/:id/row_count` but this route was never defined.

### Solution
Add flat route and `row_count` action in `DatasetsController`.

---

## 4. GROUP BY breaking pagination + legacy naming

### Problem
- `scope.count(:all)` returns a Hash with GROUP BY → crashes `pt_paginate`
- Views reference `@prompts`/`@prompt` but controller assigns `@agents`/`@agent`

### Solution
- Detect Hash result from `count` and use `.length`
- Add aliases in the agents controller

---

## 5. "Run All Tests" form blocked by hidden required field

### Problem
In dataset mode, `toggleExecutionMode()` adds `required` to `first_user_message` (a single-mode field). Since this field is hidden, the browser refuses to submit: *"An invalid form control is not focusable"*.

### Solution
`toggleExecutionMode()` now skips when run mode is "dataset".

---

## Tested on
- Rails 8.2 app with **Webpacker 5.4** + Sprockets + **will_paginate 4.0** (SideCare)
- 46/46 Stimulus controllers registered
- 12 pages tested: all 200 OK
- Run All Tests modal: form submits successfully
- 0 JS console errors
- 292 controller/request specs passing