### PR TITLE
Fix variable injection and planning phase tool_choice

### DIFF
--- a/app/services/prompt_tracker/task_agent_runtime_service.rb
+++ b/app/services/prompt_tracker/task_agent_runtime_service.rb
@@ -52,7 +52,7 @@ module PromptTracker
     def initialize(task_agent:, task_run:, variables: nil, logger: nil)
       @task_agent = task_agent
       @task_run = task_run
-      @variables = variables || task_agent.task_configuration.dig(:variables) || {}
+      @variables = resolve_variables(variables)
       @iteration_count = 0
       @conversation_history = []
       @start_time = Time.current
@@ -183,7 +183,24 @@ module PromptTracker
 
     def render_initial_prompt
       template = task_agent.task_configuration[:initial_prompt]
-      render_template(template)
+      rendered = render_template(template)
+
+      # Append any variables that are not referenced in the template
+      # so the LLM always knows about them even if the user forgot {{placeholders}}
+      if variables.present?
+        unreferenced = variables.reject { |key, _| template&.include?("{{#{key}}}") }
+        if unreferenced.present?
+          rendered = rendered.to_s
+          rendered += "\n\nContext variables:\n"
+          unreferenced.each do |key, value|
+            rendered += "- #{key}: #{value}\n"
+          end
+          @logger.info "[TaskAgentRuntimeService] 📋 Appended #{unreferenced.size} unreferenced variable(s) to initial prompt"
+        end
+      end
+
+      @logger.info "[TaskAgentRuntimeService] 📋 Rendered initial prompt: #{rendered[0..200]}..."
+      rendered
     end
 
     # Render system prompt with variable substitution.
@@ -209,6 +226,27 @@ module PromptTracker
         rendered.gsub!("{{#{key}}}", value.to_s)
       end
       rendered
+    end
+
+    # Resolve variables from multiple sources (in priority order):
+    # 1. Explicitly passed variables (from API call)
+    # 2. task_run.variables_used (set when the run was created, includes merged defaults)
+    # 3. task_config variables (default values from deployed agent config)
+    # 4. Empty hash as fallback
+    #
+    # @param explicit_variables [Hash, nil] explicitly passed variables
+    # @return [Hash] resolved variables
+    def resolve_variables(explicit_variables)
+      resolved = explicit_variables.presence ||
+                 task_run&.variables_used.presence ||
+                 task_agent.task_configuration.dig(:variables) ||
+                 {}
+
+      # Stringify keys for consistent template substitution
+      resolved = resolved.transform_keys(&:to_s)
+
+      @logger&.info "[TaskAgentRuntimeService] 📋 Resolved variables: #{resolved.inspect}"
+      resolved
     end
 
     # Execute planning phase (Iteration 0)

--- a/app/services/prompt_tracker/task_agent_runtime_service/openai_responses.rb
+++ b/app/services/prompt_tracker/task_agent_runtime_service/openai_responses.rb
@@ -63,14 +63,25 @@ module PromptTracker
         @logger.info "[TaskAgentRuntimeService::OpenaiResponses] 🌡️  Temperature: #{temperature.inspect} (model: #{model_config['model']})"
         @logger.info "[TaskAgentRuntimeService::OpenaiResponses] ⏳ Making initial API call (this may take a while for GPT-5)..."
 
-        response = LlmClients::OpenaiResponseService.call(
+        # During planning phase, force the LLM to call create_plan by setting tool_choice
+        tool_choice_param = if phase == :planning && tools_array.present?
+          @logger.info "[TaskAgentRuntimeService::OpenaiResponses] 🎯 Forcing tool_choice=required for planning phase"
+          "required"
+        else
+          nil
+        end
+
+        call_params = {
           model: model_config["model"],
           input: user_prompt,
           instructions: system_prompt,
           tools: tools,
           tool_config: tool_config,
           temperature: temperature
-        )
+        }
+        call_params[:tool_choice] = tool_choice_param if tool_choice_param
+
+        response = LlmClients::OpenaiResponseService.call(**call_params)
 
         @logger.info "[TaskAgentRuntimeService::OpenaiResponses] ✅ Initial API call completed"
         @logger.info "[TaskAgentRuntimeService::OpenaiResponses] 📊 Response has #{response[:tool_calls]&.length || 0} tool calls"


### PR DESCRIPTION
## Fixes

### 1. Variable injection not working
**Root cause**: Variables from `task_config` were not reliably reaching the prompts. The `ExecuteTaskAgentJob` passes `options[:variables]` as `nil` (since `run_now` action doesn't pass variables to the job). The fallback in `initialize` should have worked via `task_configuration.dig(:variables)`, but wasn't reliable.

**Fix**: Added `resolve_variables()` method that checks multiple sources in priority order:
1. Explicitly passed variables (from API call)
2. `task_run.variables_used` (set when the run was created with merged defaults)
3. `task_config` variables (default values)
4. Empty hash fallback

Also: **Appends unreferenced variables** to the initial prompt as `Context variables` section, so the LLM always knows about them even if the user prompt template doesn't use `{{placeholder}}` syntax.

### 2. Planning phase always failing
**Root cause**: During planning phase, the LLM was given `create_plan` as a tool but wasn't forced to call it. The LLM would respond with text instead, resulting in no plan being created and `get_plan` returning 'No plan exists' during execution.

**Fix**: Set `tool_choice='required'` during planning phase to force the LLM to call the `create_plan` function.

### 3. Debug logging
Added logging for variable resolution and rendered prompts to help debug similar issues.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author