### PR TITLE
fix: three install-phase regressions (evaluations 500, playground helpers, evaluator_configs prefill)

### DIFF
--- a/app/controllers/prompt_tracker/evaluations_controller.rb
+++ b/app/controllers/prompt_tracker/evaluations_controller.rb
@@ -6,7 +6,12 @@ module PromptTracker
     # GET /evaluations
     # List all evaluations with filtering
     def index
-      @evaluations = Evaluation.includes(llm_response: { agent_version: :agent })
+      # The index view renders rows from `evaluation.llm_response.agent_version.agent`;
+      # evaluations with evaluation_context == "test_run" or "manual" may have a nil
+      # llm_response (belongs_to is optional), so we exclude them here rather than in
+      # the view so pagination and summary stats stay consistent.
+      @evaluations = Evaluation.where.not(llm_response_id: nil)
+                               .includes(llm_response: { agent_version: :agent })
 
       # Filter by evaluator_type
       @evaluations = @evaluations.where(evaluator_type: params[:evaluator_type]) if params[:evaluator_type].present?

--- a/app/helpers/prompt_tracker/evaluator_configs_helper.rb
+++ b/app/helpers/prompt_tracker/evaluator_configs_helper.rb
@@ -59,6 +59,28 @@ module PromptTracker
       }
     }.freeze
 
+    # Serialize a test's existing evaluator_configs into the JSON shape
+    # expected by evaluator_configs_controller.js#initializeConfigsFromHiddenField
+    # (an array of { evaluator_key, config }). The association getter on Test
+    # returns an AR::Associations::CollectionProxy, which Rails renders via
+    # .to_s (= #<PromptTracker::...>) when fed directly to hidden_field — that
+    # string is not valid JSON and makes the Stimulus controller skip prefill.
+    #
+    # @param test [PromptTracker::Test]
+    # @return [String] JSON array string, or "" when no configs exist
+    def evaluator_configs_json_for(test)
+      configs = Array(test.evaluator_configs)
+      return "" if configs.empty?
+
+      registry = PromptTracker::EvaluatorRegistry.all
+      configs.map do |ec|
+        entry = registry.find { |_key, meta| meta[:evaluator_class].name == ec.evaluator_type }
+        next unless entry
+
+        { evaluator_key: entry.first, config: ec.config || {} }
+      end.compact.to_json
+    end
+
     # Build form data for evaluator configuration section
     #
     # @param test [PromptTracker::Test] The test being edited

--- a/app/helpers/prompt_tracker/evaluator_configs_helper.rb
+++ b/app/helpers/prompt_tracker/evaluator_configs_helper.rb
@@ -66,11 +66,15 @@ module PromptTracker
     # .to_s (= #<PromptTracker::...>) when fed directly to hidden_field — that
     # string is not valid JSON and makes the Stimulus controller skip prefill.
     #
+    # Returns "[]" (not "") when there are no configs: if JS fails to rewrite
+    # the hidden field before submit, tests_controller_base#test_params calls
+    # JSON.parse on the raw string and an empty string would raise.
+    #
     # @param test [PromptTracker::Test]
-    # @return [String] JSON array string, or "" when no configs exist
+    # @return [String] JSON array string, "[]" when no configs exist
     def evaluator_configs_json_for(test)
       configs = Array(test.evaluator_configs)
-      return "" if configs.empty?
+      return "[]" if configs.empty?
 
       registry = PromptTracker::EvaluatorRegistry.all
       configs.map do |ec|

--- a/app/views/prompt_tracker/testing/playground/show.html.erb
+++ b/app/views/prompt_tracker/testing/playground/show.html.erb
@@ -4,8 +4,8 @@
     conversation_url = run_conversation_testing_agent_agent_version_playground_path(@prompt, @agent_version)
     reset_url = reset_conversation_testing_agent_agent_version_playground_path(@prompt, @agent_version)
   elsif @prompt
-    conversation_url = run_conversation_testing_prompt_playground_path(@prompt)
-    reset_url = reset_conversation_testing_prompt_playground_path(@prompt)
+    conversation_url = run_conversation_testing_agent_playground_path(@prompt)
+    reset_url = reset_conversation_testing_agent_playground_path(@prompt)
   else
     conversation_url = run_conversation_testing_playground_path
     reset_url = reset_conversation_testing_playground_path
@@ -81,15 +81,15 @@
        data-playground-generate-prompt-generate-url-value="<%= generate_testing_agent_agent_version_playground_path(@prompt, @agent_version) %>"
      <% elsif @prompt %>
        <% if playground_ui.include?(:preview) %>
-         data-playground-preview-preview-url-value="<%= preview_testing_prompt_playground_path(@prompt) %>"
+         data-playground-preview-preview-url-value="<%= preview_testing_agent_playground_path(@prompt) %>"
        <% end %>
-       data-playground-save-save-url-value="<%= save_testing_prompt_playground_path(@prompt) %>"
-       data-playground-save-check-version-impact-url-value="<%= check_version_impact_testing_prompt_playground_path(@prompt) %>"
+       data-playground-save-save-url-value="<%= save_testing_agent_playground_path(@prompt) %>"
+       data-playground-save-check-version-impact-url-value="<%= check_version_impact_testing_agent_playground_path(@prompt) %>"
        data-playground-save-prompt-id-value="<%= @prompt.id %>"
        data-playground-save-prompt-name-value="<%= @prompt.name %>"
-       data-playground-sync-push-url-value="<%= push_to_remote_testing_prompt_playground_path(@prompt) %>"
-       data-playground-sync-pull-url-value="<%= pull_from_remote_testing_prompt_playground_path(@prompt) %>"
-       data-playground-generate-prompt-generate-url-value="<%= generate_testing_prompt_playground_path(@prompt) %>"
+       data-playground-sync-push-url-value="<%= push_to_remote_testing_agent_playground_path(@prompt) %>"
+       data-playground-sync-pull-url-value="<%= pull_from_remote_testing_agent_playground_path(@prompt) %>"
+       data-playground-generate-prompt-generate-url-value="<%= generate_testing_agent_playground_path(@prompt) %>"
        <% if @version %>
          data-playground-save-version-id-value="<%= @version.id %>"
          data-playground-save-current-version-number-value="<%= @version.version_number %>"

--- a/app/views/prompt_tracker/testing/tests/_form.html.erb
+++ b/app/views/prompt_tracker/testing/tests/_form.html.erb
@@ -62,7 +62,10 @@
         <% end %>
       </div>
 
-      <%= f.hidden_field :evaluator_configs, id: "evaluator_configs_json", data: { evaluator_configs_target: "hiddenField" } %>
+      <%= f.hidden_field :evaluator_configs,
+                         id: "evaluator_configs_json",
+                         value: evaluator_configs_json_for(test),
+                         data: { evaluator_configs_target: "hiddenField" } %>
     </div>
   </div>
 


### PR DESCRIPTION
## Context

While installing PromptTracker into a host Rails app (SideCare-Core), a systematic walk of every page under `/prompt_tracker` surfaced three bugs that only show up once the DB contains realistic data. The three fixes are independent, one commit each. A fourth commit addresses a follow-up caught by Sentry's PR reviewer on an internal fork PR.

Same four fixes landed on `lounna-team/PromptTracker` master via lounna-team PR #3 and were validated end-to-end against a host app before cherry-picking here onto `upstream/master` (99bd545).

## Bug 1 — `GET /evaluations` crashes on evaluations without an `llm_response`

**Repro.** Any DB with at least one `Evaluation` whose `evaluation_context` is `test_run` or `manual` (`llm_response_id` can be nil per the optional belongs_to).

**Trace.**
```
ActionView::Template::Error (undefined method 'agent_version' for nil)
  137:   <% @evaluations.each do |evaluation| %>
  138:     <% response = evaluation.llm_response %>
  139:     <% prompt = response.agent_version.agent %>
```

**Cause.** `Evaluation#llm_response` is `belongs_to ... optional: true` (`app/models/prompt_tracker/evaluation.rb:59-62`), but `evaluations/index.html.erb` derefs `response.id` / `response.agent_version.version_number` unconditionally.

**Fix (commit 1).** Scope the controller query with `.where.not(llm_response_id: nil)`. Consistent with `Monitoring::EvaluationsController#index`, which already uses `Evaluation.tracked`. Pagination counts and summary stats stay aligned with what the view renders.

## Bug 2 — `GET /testing/agents/:id/playground` crashes on stale helper names

**Repro.** `GET /prompt_tracker/testing/agents/1/playground` (agent-scoped playground without a pinned version).

**Trace.**
```
ActionView::Template::Error (undefined method 'run_conversation_testing_prompt_playground_path'
  for an instance of #<Class:...>)
     7:     conversation_url = run_conversation_testing_prompt_playground_path(@prompt)
```

**Cause.** The `elsif @prompt` branch of `testing/playground/show.html.erb` calls eight `*_testing_prompt_playground_path` helpers that don't exist. Leftover from the `Prompt -> Agent` rename. `config/routes.rb` (nested `resources :agents do resource :playground`) generates `*_testing_agent_playground_path` instead.

**Fix (commit 2).** Rename the eight occurrences. `grep -rn testing_prompt_playground app/` returns zero matches after the fix.

## Bug 3 — Test edit form fails to prefill existing `evaluator_configs`

**Repro.** Open any page that renders the test edit modal (e.g. `/testing/agents/:id/versions/:v` once a test exists). Browser console:

```
[EvaluatorConfigs] Could not parse existing hidden field value: SyntaxError:
  Unexpected token '#', "#<PromptTr"... is not valid JSON
    at JSON.parse (<anonymous>)
    at initializeConfigsFromHiddenField (evaluator_configs_controller.js:44:38)
```

**Cause.** `testing/tests/_form.html.erb:65` was `f.hidden_field :evaluator_configs, ...`. The getter `Test#evaluator_configs` is the `has_many` association — returns an `AR::Associations::CollectionProxy`. Rails serializes it via `.to_s`, which is the inspect string `#<PromptTracker::EvaluatorConfig::ActiveRecord_Associations_CollectionProxy:...>`. The Stimulus controller calls `JSON.parse(...)` on that value and silently skips prefill on every edit.

Submit still worked (JS rewrites the field before submit; the custom `evaluator_configs=` setter on the model accepts a JSON string). Bug only manifested on the client side, making existing configs invisible on edit.

**Fix (commits 3 + 4).**
- New helper `EvaluatorConfigsHelper#evaluator_configs_json_for(test)` serializes the association into the `[{ evaluator_key, config }, ...]` shape the JS expects. Keys derived via `EvaluatorRegistry` (`evaluator_class.name -> key`) so there's no duplicated naming convention.
- Hidden field passes that JSON as `value:`.
- Empty case returns `"[]"` instead of `""` so `tests_controller_base#test_params` (`JSON.parse(permitted[:evaluator_configs])`) stays safe if JS ever fails to rewrite the field before submit. (Credit: Sentry PR reviewer on the internal fork PR.)

## Out of scope — unrelated regression noticed during testing

While validating this branch against `upstream/master`, `/testing/agents/:id/playground` and `/testing/agents/:id/versions/:v` still return 500 even with my helper rename applied, due to a separate bug introduced by the MCP feature (commit 19694e9):

```
ActionView::Template::Error (undefined local variable or method 'mcp_servers'
  for an instance of PromptTracker::AgentVersion)
  41:     <!-- MCP Servers -->
  42:     <% if version.has_mcp_servers? %>
  43:       ...
```

A partial references a bare `mcp_servers` (unqualified) inside the `if version.has_mcp_servers?` block. `AgentVersion` exposes `has_mcp_servers?` and `mcp_server_names` but not `mcp_servers`. Left out of this PR — happy to open a separate one if you want me to follow up.

## Verification

Validated against `upstream/master` + these 4 commits running locally with `gem "prompt_tracker", path: "..."` in a host Rails app:

| URL | Before | After |
| --- | --- | --- |
| `/evaluations` | 500 (agent_version for nil) | 200 |
| `/testing/agents/1/playground` | 500 (prompt_playground helper) | no helper error (hits the out-of-scope mcp_servers bug further down) |
| `/testing/agents/1/versions/1` console | 3x JSON.parse SyntaxError | clean JSON round-trip (once mcp_servers bug is gone) |

## Notes

- 4 atomic commits, squashable if you prefer.
- No schema or routing changes.
- No new dependencies.
- Same diff landed on `lounna-team/PromptTracker` master (internal fork) via lounna-team PR #3; CI green (lint + test).
