### PR TITLE
fix: define PromptTracker::ApplicationCable::Channel base class

### DIFF
--- a/app/channels/prompt_tracker/application_cable/channel.rb
+++ b/app/channels/prompt_tracker/application_cable/channel.rb
@@ -1,0 +1,6 @@
+module PromptTracker
+  module ApplicationCable
+    class Channel < ::ActionCable::Channel::Base
+    end
+  end
+end


### PR DESCRIPTION
## Bug

`agent_version_channel.rb:25` and `test_run_channel.rb:24` both inherit from `ApplicationCable::Channel` (no leading `::`). Inside the `PromptTracker` module, Ruby resolves that to `PromptTracker::ApplicationCable::Channel` first, but no such class is defined.

Apps doing `Rails.application.eager_load!` (database_consistency, brakeman, `bin/rails zeitwerk:check`, etc.) crash with:

```
NameError: uninitialized constant PromptTracker::ApplicationCable
  Did you mean? PromptTracker::ApplicationJob / PromptTracker::ApplicationMailer
  app/channels/prompt_tracker/agent_version_channel.rb:25
```

In dev mode the bug is hidden because Rails autoload is lazy — the channels never get touched until a websocket subscription happens.

## Fix

Add `app/channels/prompt_tracker/application_cable/channel.rb` defining `PromptTracker::ApplicationCable::Channel < ::ActionCable::Channel::Base`. Matches the engine's existing convention for `ApplicationJob`, `ApplicationMailer`, `ApplicationRecord`, `ApplicationController`, `ApplicationHelper` — all already namespaced under `PromptTracker::`.

Inherits from `::ActionCable::Channel::Base` directly rather than from a host `ApplicationCable::Channel`, so host apps without an `app/channels/` directory (which is fine — channels aren't auto-generated unless used) don't need to add one.

## Verification

With this change applied via `gem 'prompt_tracker', path: ...` on a host Rails edge app, `bundle exec database_consistency` no longer crashes during `eager_load!` and produces its normal report.

## Notes

- Same change merged on `lounna-team/PromptTracker` master via [#4](https://github.com/lounna-team/PromptTracker/pull/4).
- Single commit, no schema or routing changes.
- No new dependencies.
