### PR TITLE
fix: unblock RSpec suite (OpenAI constant, playground render regression, stale specs)

### DIFF
--- a/app/javascript/prompt_tracker/controllers/playground_prompt_editor_controller.js
+++ b/app/javascript/prompt_tracker/controllers/playground_prompt_editor_controller.js
@@ -4,26 +4,28 @@ import { Controller } from "@hotwired/stimulus"
  * Playground Prompt Editor Controller
  *
  * @description
- * Manages prompt text editing functionality including system prompt
- * textarea, character counting, and tab key indentation.
+ * Manages prompt text editing functionality including system prompt and user prompt
+ * textareas, character counting, and tab key indentation.
  *
  * @responsibilities
- * - Manage system prompt textarea editor
+ * - Manage system prompt and user prompt textarea editors
  * - Handle tab key for 2-space indentation
  * - Update character count with color coding
  * - Dispatch promptChanged events when content changes
  *
  * @targets
  * - systemPromptEditor: System prompt textarea
+ * - userPromptEditor: User prompt textarea
  * - charCount: Character count display element
  *
  * @events_dispatched
- * - playground-prompt-editor:promptChanged: When prompt changes
+ * - playground-prompt-editor:promptChanged: When any prompt changes
  *   Detail: { systemPrompt, userPrompt }
  */
 export default class extends Controller {
   static targets = [
     "systemPromptEditor",
+    "userPromptEditor",
     "charCount"
   ]
 
@@ -42,6 +44,15 @@ export default class extends Controller {
         if (e.key === "Tab") {
           e.preventDefault()
           this.insertTabSpaces(this.systemPromptEditorTarget)
+        }
+      })
+    }
+
+    if (this.hasUserPromptEditorTarget) {
+      this.userPromptEditorTarget.addEventListener("keydown", (e) => {
+        if (e.key === "Tab") {
+          e.preventDefault()
+          this.insertTabSpaces(this.userPromptEditorTarget)
         }
       })
     }
@@ -69,14 +80,27 @@ export default class extends Controller {
   }
 
   /**
+   * Action: User prompt input
+   */
+  onUserPromptInput() {
+    console.log("[PlaygroundPromptEditorController] onUserPromptInput")
+    this.updateCharCount()
+    this.dispatchPromptChanged()
+  }
+
+  /**
    * Update character count with color coding
    */
   updateCharCount() {
     if (!this.hasCharCountTarget) return
 
-    const totalLength = this.hasSystemPromptEditorTarget
+    const systemLength = this.hasSystemPromptEditorTarget
       ? this.systemPromptEditorTarget.value.length
       : 0
+    const userLength = this.hasUserPromptEditorTarget
+      ? this.userPromptEditorTarget.value.length
+      : 0
+    const totalLength = systemLength + userLength
 
     this.charCountTarget.textContent = `${totalLength.toLocaleString()} chars`
 
@@ -115,6 +139,9 @@ export default class extends Controller {
   }
 
   getUserPrompt() {
-    return ""
+    return this.hasUserPromptEditorTarget
+      ? this.userPromptEditorTarget.value
+      : ""
   }
 }
+

--- a/app/views/prompt_tracker/testing/playground/_prompt_editors.html.erb
+++ b/app/views/prompt_tracker/testing/playground/_prompt_editors.html.erb
@@ -30,6 +30,10 @@
       <%= render "prompt_tracker/testing/playground/system_prompt",
                  playground_ui: playground_ui,
                  version: version %>
+
+      <%= render "prompt_tracker/testing/playground/user_prompt",
+                 playground_ui: playground_ui,
+                 version: version %>
     </div>
   </div>
 </div>

--- a/spec/controllers/prompt_tracker/deployed_agents_controller_spec.rb
+++ b/spec/controllers/prompt_tracker/deployed_agents_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe PromptTracker::DeployedAgentsController, type: :controller do
             agent_type: "task",
             task_config: {
               initial_prompt: "Fetch data from {{source_url}}",
-              variables: '{"source_url": "https://example.com"}',
+              variables: { source_url: "https://example.com" },
               execution: {
                 max_iterations: 10,
                 timeout_seconds: 7200

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,12 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 
 require "rspec/rails"
 require "rails-controller-testing" # For assigns and assert_template in controller tests
+
+# The engine requires "openai" lazily inside service methods to keep production
+# load times low. Specs reference OpenAI::Client at let-time (before the service
+# method runs), so we have to load it eagerly here or every OpenAI-touching spec
+# blows up at module load with `uninitialized constant OpenAI`.
+require "openai"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/services/prompt_tracker/llm_clients/openai_assistant_service_spec.rb
+++ b/spec/services/prompt_tracker/llm_clients/openai_assistant_service_spec.rb
@@ -8,11 +8,11 @@ module PromptTracker
     let(:user_message) { "What's the weather in Berlin?" }
     let(:thread_id) { "thread_xyz789" }
     let(:run_id) { "run_123456" }
-    let(:mock_client) { instance_double(OpenAI::Client) }
+    let(:mock_client) { instance_double(::OpenAI::Client) }
 
     before do
       # Mock OpenAI client
-      allow(OpenAI::Client).to receive(:new).and_return(mock_client)
+      allow(::OpenAI::Client).to receive(:new).and_return(mock_client)
       # Configure API key through the configuration system
       allow(PromptTracker.configuration).to receive(:api_key_for).with(:openai).and_return("test-api-key")
     end

--- a/spec/services/prompt_tracker/llm_clients/openai_response_service_spec.rb
+++ b/spec/services/prompt_tracker/llm_clients/openai_response_service_spec.rb
@@ -11,7 +11,7 @@ module PromptTracker
     let(:mock_responses) { double("responses") }
 
     before do
-      allow(OpenAI::Client).to receive(:new).and_return(mock_client)
+      allow(::OpenAI::Client).to receive(:new).and_return(mock_client)
       allow(mock_client).to receive(:responses).and_return(mock_responses)
       allow(PromptTracker.configuration).to receive(:api_key_for).with(:openai).and_return("test-api-key")
     end

--- a/spec/services/prompt_tracker/openai/assistants/model_config_normalizer_spec.rb
+++ b/spec/services/prompt_tracker/openai/assistants/model_config_normalizer_spec.rb
@@ -33,7 +33,7 @@ module PromptTracker
               )
             end
 
-            let(:openai_client) { instance_double(OpenAI::Client) }
+            let(:openai_client) { instance_double(::OpenAI::Client) }
             let(:vector_stores_api) { instance_double("VectorStores") }
 
             before do

--- a/spec/services/prompt_tracker/openai/vector_store_operations_spec.rb
+++ b/spec/services/prompt_tracker/openai/vector_store_operations_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module PromptTracker
   module Openai
     RSpec.describe VectorStoreOperations, type: :service do
-      let(:mock_client) { instance_double(OpenAI::Client) }
+      let(:mock_client) { instance_double(::OpenAI::Client) }
       let(:mock_vector_stores) { double("vector_stores") }
       let(:mock_vector_store_files) { double("vector_store_files") }
       let(:mock_files) { double("files") }
@@ -15,7 +15,7 @@ module PromptTracker
         allow(PromptTracker.configuration).to receive(:api_key_for).with(:openai).and_return("test_api_key")
 
         # Stub OpenAI client
-        allow(OpenAI::Client).to receive(:new).with(access_token: "test_api_key").and_return(mock_client)
+        allow(::OpenAI::Client).to receive(:new).with(access_token: "test_api_key").and_return(mock_client)
         allow(mock_client).to receive(:vector_stores).and_return(mock_vector_stores)
         allow(mock_client).to receive(:vector_store_files).and_return(mock_vector_store_files)
         allow(mock_client).to receive(:files).and_return(mock_files)

--- a/spec/services/prompt_tracker/prompt_generator_service_spec.rb
+++ b/spec/services/prompt_tracker/prompt_generator_service_spec.rb
@@ -147,13 +147,10 @@ module PromptTracker
           PromptTracker.configuration.configuration_provider = nil
         end
 
-        let(:mock_context) { double("RubyLLM::Context") }
-        let(:mock_config_block) { double("config_block").as_null_object }
-
         before do
-          # RubyLLM.context yields a config block for setting API keys, then returns a context
-          allow(RubyLLM).to receive(:context).and_yield(mock_config_block).and_return(mock_context)
-          allow(mock_context).to receive(:chat).and_return(mock_chat)
+          # The service applies the dynamic config via RubyLlmService.with_dynamic_config,
+          # which yields RubyLLM (the module) and the calling code does RubyLLM.chat(...).
+          allow(RubyLLM).to receive(:chat).and_return(mock_chat)
         end
 
         it 'detects dynamic_configuration is enabled' do
@@ -164,7 +161,7 @@ module PromptTracker
         end
 
         it 'uses the dynamically configured model' do
-          expect(mock_context).to receive(:chat).with(model: 'gpt-4o').at_least(:once).and_return(mock_chat)
+          expect(RubyLLM).to receive(:chat).with(model: 'gpt-4o').at_least(:once).and_return(mock_chat)
           allow(mock_chat).to receive(:ask).and_return(mock_response, mock_variables_response, mock_generation_response)
 
           described_class.generate(description: description)

--- a/spec/services/prompt_tracker/remote_entity/openai/assistants/pull_service_spec.rb
+++ b/spec/services/prompt_tracker/remote_entity/openai/assistants/pull_service_spec.rb
@@ -24,11 +24,11 @@ module PromptTracker
               })
           end
 
-          let(:openai_client) { instance_double(OpenAI::Client) }
+          let(:openai_client) { instance_double(::OpenAI::Client) }
           let(:assistants_api) { instance_double("Assistants") }
 
           before do
-            allow(OpenAI::Client).to receive(:new).and_return(openai_client)
+            allow(::OpenAI::Client).to receive(:new).and_return(openai_client)
             allow(openai_client).to receive(:assistants).and_return(assistants_api)
             allow(PromptTracker.configuration).to receive(:api_key_for).with(:openai).and_return("test-api-key")
           end

--- a/spec/services/prompt_tracker/remote_entity/openai/assistants/push_service_spec.rb
+++ b/spec/services/prompt_tracker/remote_entity/openai/assistants/push_service_spec.rb
@@ -22,11 +22,11 @@ module PromptTracker
               })
           end
 
-          let(:openai_client) { instance_double(OpenAI::Client) }
+          let(:openai_client) { instance_double(::OpenAI::Client) }
           let(:assistants_api) { instance_double("Assistants") }
 
           before do
-            allow(OpenAI::Client).to receive(:new).and_return(openai_client)
+            allow(::OpenAI::Client).to receive(:new).and_return(openai_client)
             allow(openai_client).to receive(:assistants).and_return(assistants_api)
             allow(PromptTracker.configuration).to receive(:api_key_for).with(:openai).and_return("test-api-key")
           end

--- a/spec/services/prompt_tracker/sync_openai_assistants_to_agent_versions_service_spec.rb
+++ b/spec/services/prompt_tracker/sync_openai_assistants_to_agent_versions_service_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 module PromptTracker
   RSpec.describe SyncOpenaiAssistantsToAgentVersionsService, type: :service do
-    let(:mock_client) { instance_double(OpenAI::Client) }
+    let(:mock_client) { instance_double(::OpenAI::Client) }
     let(:mock_assistants) { double("assistants") }
 
     let(:assistant_data_1) do
@@ -43,7 +43,7 @@ module PromptTracker
       allow(PromptTracker.configuration).to receive(:api_key_for).with(:openai).and_return("test_api_key")
 
       # Stub OpenAI client
-      allow(OpenAI::Client).to receive(:new).with(access_token: "test_api_key").and_return(mock_client)
+      allow(::OpenAI::Client).to receive(:new).with(access_token: "test_api_key").and_return(mock_client)
       allow(mock_client).to receive(:assistants).and_return(mock_assistants)
       allow(mock_assistants).to receive(:list).and_return({
         "data" => [ assistant_data_1, assistant_data_2 ]


### PR DESCRIPTION
## Bug

`bundle exec rspec` on master has been failing for the last several commits — initially with `NameError: uninitialized constant PromptTracker::Openai::Assistants::OpenAI`, plus 18 system spec failures around the playground textarea, plus 2 stale specs referencing refactored APIs. Same set of failures surfaced on the CI of #57.

This PR brings the suite back to **0 failures** on the affected files.

## Fixes

### 1. Eager `require "openai"` in `spec/rails_helper.rb`

The engine calls `require "openai"` lazily from inside service methods. Specs that mock `OpenAI::Client` at let-time evaluate before any service method runs, so the `OpenAI` constant is not loaded and Ruby's nested constant lookup inside `PromptTracker::Openai::Assistants::*` raises. Loading `openai` once in `rails_helper.rb` makes the top-level `OpenAI` constant available to every spec without forcing production code to eager-load it.

### 2. Qualify `OpenAI::Client` with leading `::` in nested-namespace specs (12 lines, 7 files)

Defensive: makes the constant lookup explicit at point of use, independent of load order.

### 3. Restore `_user_prompt` render + matching JS hooks

Commit 04acd03 ("Fix") accidentally:
- removed the `render "user_prompt"` call in `_prompt_editors.html.erb` (the `_user_prompt.html.erb` partial itself stayed on disk, just unreachable)
- stripped the matching `userPromptEditor` target, `onUserPromptInput` action, char count, and `getUserPrompt()` from `playground_prompt_editor_controller.js`

Effect: the User Prompt Template textarea never made it into the rendered playground page, and the variables panel never received any `promptChanged` event from the user prompt side. Restored verbatim from 9ebd235.

### 4. Align two stale specs with refactored implementations

- `deployed_agents_controller_spec POST #create with task agent` was sending `variables` as a JSON string. Commit 3b6dcaa ("Fix variables agent") changed the controller to accept `variables` as a hash of form fields. Spec now sends the matching shape.
- `prompt_generator_service_spec dynamic_configuration` block was stubbing `RubyLLM.context.chat`. The implementation now calls `RubyLLM.chat` directly through `RubyLlmService.with_dynamic_config`, which yields the `RubyLLM` module rather than a `Context`. Stub `RubyLLM.chat` instead.

## Verification

```
$ DISABLE_SIMPLECOV=1 bundle exec rspec \
    spec/services/prompt_tracker/sync_openai_assistants_to_agent_versions_service_spec.rb \
    spec/services/prompt_tracker/remote_entity/openai/assistants/push_service_spec.rb \
    spec/services/prompt_tracker/remote_entity/openai/assistants/pull_service_spec.rb \
    spec/services/prompt_tracker/llm_clients/openai_assistant_service_spec.rb \
    spec/services/prompt_tracker/llm_clients/openai_response_service_spec.rb \
    spec/services/prompt_tracker/openai/assistants/model_config_normalizer_spec.rb \
    spec/services/prompt_tracker/openai/vector_store_operations_spec.rb \
    spec/system/prompt_tracker/playground_controllers_spec.rb \
    spec/system/prompt_tracker/playground_generate_spec.rb \
    spec/services/prompt_tracker/prompt_generator_service_spec.rb \
    spec/controllers/prompt_tracker/deployed_agents_controller_spec.rb

# 0 failures across all originally-failing files.
```

Before this PR: 20 failures. After: 0.

## Notes

- 4 atomic commits (eager require / `::` prefix / playground regression / stale specs).
- Could be applied to `lib/prompt_tracker.rb` (eager `require "openai"`) but that would force every host app loading the engine to pay the OpenAI load cost even if they only use Anthropic / other providers. Keeping the load in `rails_helper.rb` is spec-only and doesn't regress production startup.
- No schema or routing changes.
