### PR TITLE
Make container callback path configurable

### DIFF
--- a/app/services/prompt_tracker/container_orchestrator.rb
+++ b/app/services/prompt_tracker/container_orchestrator.rb
@@ -315,8 +315,10 @@ module PromptTracker
     end
 
     def callback_url
-      base = PromptTracker.configuration.agent_base_url
-      "#{base}/prompt_tracker/internal/task_run_events"
+      base = PromptTracker.configuration.agent_base_url.to_s.sub(%r{/+\z}, "")
+      path = PromptTracker.configuration.agent_callback_path.to_s
+      path = "/#{path}" unless path.start_with?("/")
+      "#{base}#{path}"
     end
 
     def resource_limits

--- a/lib/prompt_tracker/configuration.rb
+++ b/lib/prompt_tracker/configuration.rb
@@ -236,6 +236,15 @@ module PromptTracker
     # @return [Integer]
     attr_accessor :max_concurrent_containers
 
+    # Path the container POSTs callback events to, appended to `agent_base_url`.
+    # Defaults to "/prompt_tracker/internal/task_run_events" — the path the
+    # engine routes resolve to when mounted at "/prompt_tracker". Override
+    # this when the engine is mounted elsewhere (e.g. multi-tenant hosts that
+    # mount under "/orgs/:org_slug/app") and expose an alternate route to the
+    # internal callback controller.
+    # @return [String]
+    attr_accessor :agent_callback_path
+
     # MCP (Model Context Protocol) server configurations.
     # Maps server names to connection configurations.
     # @return [Hash] hash of server name => server config hash
@@ -287,6 +296,7 @@ module PromptTracker
       }
       @max_concurrent_containers = 5
       @agent_base_url = "http://localhost:3000"
+      @agent_callback_path = "/prompt_tracker/internal/task_run_events"
       @default_deployment_config = {
         auth: { type: "api_key" },
         rate_limit: { requests_per_minute: 60 },

--- a/spec/services/prompt_tracker/container_orchestrator_spec.rb
+++ b/spec/services/prompt_tracker/container_orchestrator_spec.rb
@@ -215,5 +215,31 @@ module PromptTracker
         expect(cmd).to include("prompt-tracker-agent-runtime:latest")
       end
     end
+
+    describe "#callback_url" do
+      it "joins agent_base_url with the default callback path" do
+        PromptTracker.configuration.agent_base_url = "http://example.test:3000"
+        PromptTracker.configuration.agent_callback_path = "/prompt_tracker/internal/task_run_events"
+
+        expect(orchestrator.send(:callback_url))
+          .to eq("http://example.test:3000/prompt_tracker/internal/task_run_events")
+      end
+
+      it "respects a custom agent_callback_path for hosts that mount the engine elsewhere" do
+        PromptTracker.configuration.agent_base_url = "http://example.test:3000"
+        PromptTracker.configuration.agent_callback_path = "/internal/task_callbacks"
+
+        expect(orchestrator.send(:callback_url))
+          .to eq("http://example.test:3000/internal/task_callbacks")
+      end
+
+      it "tolerates trailing slash on base_url and missing leading slash on path" do
+        PromptTracker.configuration.agent_base_url = "http://example.test:3000/"
+        PromptTracker.configuration.agent_callback_path = "internal/task_callbacks"
+
+        expect(orchestrator.send(:callback_url))
+          .to eq("http://example.test:3000/internal/task_callbacks")
+      end
+    end
   end
 end

--- a/spec/support/prompt_tracker_configuration_reset.rb
+++ b/spec/support/prompt_tracker_configuration_reset.rb
@@ -28,6 +28,7 @@ RSpec.configure do |config|
     PROMPT_TRACKER_CONFIG_SNAPSHOT[:configuration_provider] = base_config.configuration_provider
     PROMPT_TRACKER_CONFIG_SNAPSHOT[:url_options_provider] = base_config.url_options_provider
     PROMPT_TRACKER_CONFIG_SNAPSHOT[:agent_base_url] = base_config.agent_base_url
+    PROMPT_TRACKER_CONFIG_SNAPSHOT[:agent_callback_path] = base_config.agent_callback_path
     PROMPT_TRACKER_CONFIG_SNAPSHOT[:default_deployment_config] = base_config.default_deployment_config.deep_dup
   end
 
@@ -47,6 +48,7 @@ RSpec.configure do |config|
     config_obj.configuration_provider = snapshot[:configuration_provider]
     config_obj.url_options_provider = snapshot[:url_options_provider]
     config_obj.agent_base_url = snapshot[:agent_base_url]
+    config_obj.agent_callback_path = snapshot[:agent_callback_path]
     config_obj.default_deployment_config = snapshot[:default_deployment_config].deep_dup
 
       PromptTracker::EvaluatorRegistry.reset!


### PR DESCRIPTION
## Summary
- Adds `config.agent_callback_path` to the PromptTracker `Configuration`, defaulting to the existing `/prompt_tracker/internal/task_run_events`.
- The `ContainerOrchestrator#callback_url` now joins `agent_base_url` + `agent_callback_path`, with normalization for stray leading/trailing slashes.
- Snapshots the new attribute in the spec configuration helper.
- Adds spec coverage for the default path, a custom path, and a slash-normalization case.

## Why
The orchestrator (introduced in #59) hardcoded the callback URL path as `"#{agent_base_url}/prompt_tracker/internal/task_run_events"`. That works only if the host mounts the engine at `/prompt_tracker`.

Multi-tenant hosts that mount under, e.g. `/orgs/:org_slug/app`, can't easily point containers at the right endpoint — they'd have to either expose a parallel host-app route at the gem's hardcoded path (workaround the host can do today) or fork the orchestrator.

This makes the path configurable so hosts can set:

```ruby
config.agent_callback_path = "/internal/task_callbacks"
```

and route however they want.

## Test plan
- [x] `bundle exec rspec spec/services/prompt_tracker/container_orchestrator_spec.rb` (17 examples, 0 failures)
- [ ] Existing host apps using the default path keep working (default value is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)